### PR TITLE
Average air time, end on reset shot

### DIFF
--- a/Juggler.cpp
+++ b/Juggler.cpp
@@ -2,7 +2,7 @@
 #include "HelperFunctions.h"
 
 Juggler::Juggler()
-  : m_totalHits(0), m_highestHits(0), m_secondsInAir(0), m_highestSecondsInAir(0), m_lastSecondsInAir(0), m_lastTotalHits(0) {
+  : m_totalAttempts(0), m_totalHits(0), m_highestHits(0), m_secondsInAir(0), m_highestSecondsInAir(0), m_lastSecondsInAir(0), m_lastTotalHits(0), m_averageSecondsInAir(0) {
 }
 
 Juggler::~Juggler() {
@@ -37,7 +37,15 @@ void Juggler::Reset() {
 
   if (m_secondsInAir != m_lastSecondsInAir && m_secondsInAir != 0) {
     m_lastSecondsInAir = m_secondsInAir;
+
+    if (m_secondsInAir > m_highestSecondsInAir) {
+      m_highestSecondsInAir = m_secondsInAir;
+    }
+
+    m_averageSecondsInAir = (m_totalAttempts * m_averageSecondsInAir) / (m_totalAttempts + 1);
   }
+
+  m_totalAttempts++;
 
   if (m_totalHits != 0) {
     m_totalHits = 0;
@@ -66,6 +74,13 @@ void Juggler::ResetHighestAirTime() {
   m_highestSecondsInAir = 0;
 }
 
+void Juggler::ResetAll() {
+  m_totalAttempts = 0;
+  m_highestHits = 0;
+  m_highestSecondsInAir = 0;
+  m_averageSecondsInAir = 0;
+}
+
 void Juggler::Render(CanvasWrapper& canvas, std::shared_ptr<GameWrapper>  gameWrapper, int xPos, int yPos) {
 
   auto screenSize = canvas.GetSize();
@@ -73,12 +88,6 @@ void Juggler::Render(CanvasWrapper& canvas, std::shared_ptr<GameWrapper>  gameWr
   Vector2 drawPosition = { xPos, yPos };
   canvas.SetPosition(drawPosition);
   canvas.SetColor(255, 255, 255, 255);
-
-  double seconds = m_timer.ElapsedSeconds();
-
-  if (seconds > m_highestSecondsInAir) {
-    m_highestSecondsInAir = seconds;
-  }
 
   canvas.DrawString(std::string("Juggle Count:"), 2.5f, 2.5f);
 
@@ -100,7 +109,7 @@ void Juggler::Render(CanvasWrapper& canvas, std::shared_ptr<GameWrapper>  gameWr
 
   drawPosition.Y += 38;
   canvas.SetPosition(drawPosition);
-  canvas.DrawString(std::string("Current: ") + to_string(seconds, 2), 2, 2);
+  canvas.DrawString(std::string("Current: ") + to_string(m_timer.ElapsedSeconds(), 2), 2, 2);
 
   drawPosition.Y += 30;
   canvas.SetPosition(drawPosition);
@@ -109,4 +118,8 @@ void Juggler::Render(CanvasWrapper& canvas, std::shared_ptr<GameWrapper>  gameWr
   drawPosition.Y += 30;
   canvas.SetPosition(drawPosition);
   canvas.DrawString(std::string("Best: ") + to_string(m_highestSecondsInAir, 2), 2, 2);
+
+  drawPosition.Y += 30;
+  canvas.SetPosition(drawPosition);
+  canvas.DrawString(std::string("Avg: ") + to_string(m_averageSecondsInAir, 2), 2, 2);
 }

--- a/Juggler.h
+++ b/Juggler.h
@@ -14,6 +14,7 @@ public:
 
   void ResetHighestHits();
   void ResetHighestAirTime();
+  void ResetAll();
 
   void HitBall();
   void Reset();
@@ -21,6 +22,8 @@ public:
   void Unpause();
 
 private:
+  unsigned m_totalAttempts;
+
   unsigned m_totalHits;
   unsigned m_highestHits;
 
@@ -29,6 +32,7 @@ private:
 
   double m_secondsInAir;
   double m_highestSecondsInAir;
+  double m_averageSecondsInAir;
 
   Timer m_timer;
 };

--- a/JugglerPlugin.cpp
+++ b/JugglerPlugin.cpp
@@ -34,15 +34,17 @@ void JugglerPlugin::onLoad() {
 	// Game is cleaning up
 	gameWrapper->HookEvent("Function TAGame.GameEvent_TA.Destroyed", bind(&JugglerPlugin::OnFreeplayDestroy, this, std::placeholders::_1));
 
-	// Ball hits ground
+	// Juggle ends
 	gameWrapper->HookEvent("Function TAGame.Ball_TA.EventHitGround", bind(&JugglerPlugin::OnBallHitGround, this, std::placeholders::_1));
+	gameWrapper->HookEvent("Function GameEvent_Soccar_TA.Active.EndState", bind(&JugglerPlugin::OnBallHitGround, this, std::placeholders::_1));
 
 	// Car hits ball
 	gameWrapper->HookEvent("Function TAGame.Car_TA.EventHitBall", bind(&JugglerPlugin::OnCarHitBall, this, std::placeholders::_1));
 
 	// Pause menu
 	gameWrapper->HookEvent("Function TAGame.PlayerController_TA.OnOpenPauseMenu", bind(&JugglerPlugin::OnPauseMenu, this, std::placeholders::_1));
-
+	gameWrapper->HookEvent("Function ProjectX.GameInfo_X.AddPauser", bind(&JugglerPlugin::OnPauseMenu, this, std::placeholders::_1));
+	
 	// On Unpause
 	gameWrapper->HookEvent("Function ProjectX.GameInfo_X.RemovePauser", bind(&JugglerPlugin::OnUnpause, this, std::placeholders::_1));
 }


### PR DESCRIPTION
I haven't made an RL Plugin and wasn't able to run it

But just some ideas/fixes I had when using the plugin

- I wanted to know the average air time, so I tried to add that
- The timer doesn't stop on shot resets (in training) or scored goals (because the ball doesn't hit the ground), so tried to fix that
- Timer seems to keep going sometimes during pause so added another event I saw when I paused that made sense
- Often, when achieving a new best time, the last and best would be off by 0.01 even though it was the same run. Because they were calculated at different times (Reset vs Render). I moved it so all the calculation/setting happens in Reset